### PR TITLE
feature: adding nuspec file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ debug
 *.so
 *.dylib
 *.syso
+*.nuget
 
 # Test binary, built with `go test -c`
 *.test

--- a/pat.nuspec
+++ b/pat.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+  <metadata>
+    <id>pat</id>
+    <version>$version$</version>
+    <authors>Stack Exchange</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectUrl>https://github.com/StackExchange/pat</projectUrl>
+    <license type="expression">MIT</license>
+    <description>puppet agent --test wrapper</description>
+    <repository type="git" url="https://github.com/StackExchange/pat" commit="$commit$" />
+  </metadata>
+  <files>
+    <file src="pat.exe" target="pat.exe"/>
+  </files>
+</package>


### PR DESCRIPTION
Add a nuspec file so we can build a nuget package of pat.  Very simple here, no install scripts.